### PR TITLE
fix: Add handling for sub-regions that only consist of "a"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,24 @@
     "deprecation/deprecation": "warn",
     "no-console": "error",
     "no-param-reassign": "error",
+    "no-use-before-define": "error",
+    "import/order": [
+      "error",
+      {
+        "named": true,
+        "alphabetize": {
+          "order": "asc"
+        },
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "sibling",
+          "parent",
+          "index"
+        ]
+      }
+    ],
     "tsdoc/syntax": "warn",
     "@typescript-eslint/consistent-type-imports": [
       "warn",

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,5 +1,6 @@
 import { NUMBER } from "./constants";
-import { TokenType, type Region, type SubRegion } from "./types";
+import type { Region, SubRegion } from "./types";
+import { TokenType } from "./types";
 import { checkBlacklist, splice } from "./util";
 
 const getNumber = (region: Region): number => {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,6 +1,6 @@
 import { NUMBER } from "./constants";
 import { TokenType, type Region, type SubRegion } from "./types";
-import { splice } from "./util";
+import { checkBlacklist, splice } from "./util";
 
 const getNumber = (region: Region): number => {
   let sum = 0;
@@ -99,10 +99,12 @@ const replaceRegionsInText = (regions: Region[], text: string): string => {
   let replaced = text;
   let offset = 0;
   regions.forEach((region) => {
-    const length = region.end - region.start + 1;
-    const replaceWith = getNumber(region).toString();
-    replaced = splice(replaced, region.start + offset, length, replaceWith);
-    offset -= length - replaceWith.length;
+    if (!checkBlacklist(region.tokens)) {
+      const length = region.end - region.start + 1;
+      const replaceWith = getNumber(region).toString();
+      replaced = splice(replaced, region.start + offset, length, replaceWith);
+      offset -= length - replaceWith.length;
+    }
   });
   return replaced;
 };
@@ -113,6 +115,7 @@ interface CompilerParams {
 }
 
 const compiler = ({ regions, text }: CompilerParams): string | number => {
+  // If the entire string represents a number, return the number's value
   if (regions[0].end - regions[0].start === text.length - 1) {
     return getNumber(regions[0]);
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,38 +1,7 @@
 import { expect, it } from "vitest";
 import wtn from "./index";
 
-/**
- * Extra tests for reported issues
- */
-
-// it("thirty five thousand", () => {
-//   expect(wtn("thirty five thousand")).to.equal(35000);
-// });
-
-// it("one hundred and fifty thousand dollars", () => {
-//   expect(wtn("one hundred and fifty thousand dollars")).to.equal(150000);
-// });
-
-// it("twenty-one thousand five hundred seventy-six", () => {
-//   expect(wtn("twenty-one thousand five hundred seventy-six")).to.equal(21576);
-// });
-
-// it("a crab cake", () => {
-//   expect(wtn("a crab cake")).to.equal("a crab cake");
-// });
-
-/**
- * Failed after conversion to TypeScript (without any other changes)
- *
- * - Expected: `3000726`
- * - Received: `2.0000000000000004e+22`
- */
-
-// it("tree millyon sefen hunderd ant twinty sex", () => {
-//   expect(
-//     wtn("tree millyon sefen hunderd and twinty sex", { fuzzy: true })
-//   ).to.equal(3000726);
-// });
+// TODO: Fix the following failing tests
 
 /**
  * Original tests that were already failing
@@ -53,6 +22,62 @@ import wtn from "./index";
 // it('one hundred and two thousand', () => {
 //   expect(wtn('one hundred and two thousand')).to.eq(102000);
 // });
+
+/**
+ * Extra tests for reported issues
+ */
+
+// it("thirty five thousand", () => {
+//   expect(wtn("thirty five thousand")).to.equal(35000);
+// });
+
+// it("one hundred and fifty thousand dollars", () => {
+//   expect(wtn("one hundred and fifty thousand dollars")).to.equal(150000);
+// });
+
+// it("twenty-one thousand five hundred seventy-six", () => {
+//   expect(wtn("twenty-one thousand five hundred seventy-six")).to.equal(21576);
+// });
+
+/**
+ * Failed after conversion to TypeScript (without any other changes)
+ *
+ * - Expected: `3000726`
+ * - Received: `2.0000000000000004e+22`
+ */
+
+// it("tree millyon sefen hunderd ant twinty sex", () => {
+//   expect(
+//     wtn("tree millyon sefen hunderd and twinty sex", { fuzzy: true })
+//   ).to.equal(3000726);
+// });
+
+/**
+ * Tests after adding support for blacklisting a single `a` region.
+ *
+ * @see {@link https://github.com/finnfiddle/words-to-numbers/issues/30}
+ * @see {@link https://github.com/finnfiddle/words-to-numbers/issues/36}
+ */
+
+it("a", () => {
+  expect(wtn("a")).to.equal("a");
+});
+
+it("A", () => {
+  expect(wtn("A")).to.equal("A");
+});
+
+it("A crab cake", () => {
+  expect(wtn("A crab cake")).to.equal("A crab cake");
+});
+
+it("A cat and a mouse", () => {
+  expect(wtn("A cat and a mouse")).to.equal("A cat and a mouse");
+});
+
+it("A hundred cats and dogs", () => {
+  expect(wtn("A hundred cats and dogs")).to.equal("100 cats and dogs");
+});
 
 /**
  * Original tests
@@ -254,10 +279,6 @@ it("xxxxxxx one hundred", () => {
 
 it("and", () => {
   expect(wtn("and")).to.equal("and");
-});
-
-it("a", () => {
-  expect(wtn("a")).to.equal("a");
 });
 
 it("junkvalue", () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,4 @@
 import {
-  BLACKLIST_SINGULAR_WORDS,
   DECIMALS,
   JOINERS,
   MAGNITUDE_KEYS,
@@ -12,6 +11,7 @@ import {
 import fuzzyMatch from "./fuzzy-match";
 import { TokenType } from "./types";
 import type { Region, SubRegion, Token, WordsToNumbersOptions } from "./types";
+import { checkBlacklist } from "./util";
 
 enum Action {
   SKIP,
@@ -269,10 +269,6 @@ const checkIfTokenFitsRegion = (
 
   return Action.NOPE;
 };
-
-const checkBlacklist = (tokens: Token[]): boolean =>
-  tokens.length === 1 &&
-  BLACKLIST_SINGULAR_WORDS.includes(tokens[0].lowerCaseValue);
 
 const matchRegions = (
   tokens: Token[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export interface WordsToNumbersOptions {
   impliedHundreds?: boolean;
 }
 
-export enum TokenType {
+export const enum TokenType {
   UNIT = 0,
   TEN = 1,
   MAGNITUDE = 2,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export interface WordsToNumbersOptions {
   impliedHundreds?: boolean;
 }
 
-export const enum TokenType {
+export enum TokenType {
   UNIT = 0,
   TEN = 1,
   MAGNITUDE = 2,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,6 @@
+import { BLACKLIST_SINGULAR_WORDS } from "./constants";
+import type { Token } from "./types";
+
 export const splice = (
   str: string,
   index: number,
@@ -13,4 +16,15 @@ export const splice = (
   }
 
   return str.slice(0, i) + (add || "") + str.slice(i + count);
+};
+
+/**
+ * Determine whether the set of tokens is a singular blacklisted word.
+ * The only blacklisted singular word currently is "a".
+ */
+export const checkBlacklist = (tokens: Token[]): boolean => {
+  return (
+    tokens.length === 1 &&
+    BLACKLIST_SINGULAR_WORDS.includes(tokens[0].lowerCaseValue)
+  );
 };


### PR DESCRIPTION
Currently, there is an issue with the inline number replacement in strings consisting of more than just numbers, where the word "a" is always replaced with a "1", even if it's on it's own. This has been mentioned a few times in issues on the original project:

- https://github.com/finnfiddle/words-to-numbers/issues/36
- https://github.com/finnfiddle/words-to-numbers/issues/30

This behavior really doesn't make sense, and it's already handled for cases with only the word "a" (in the existing code, the standalone word "a" isn't replaced with anything). So This is meant to fix the rest of the cases where the word has no neighboring numbers to make it into an actual number.

I added some new test cases around this to ensure it works as expected.

```ts
// This is an existing test case that already passed
it("a", () => {
  expect(wtn("a")).to.equal("a");
});

// This case also already passed
it("A", () => {
  expect(wtn("A")).to.equal("A");
});

// Previously, these two cases would all result in the "a"s being replaced with "1"
it("A crab cake", () => {
  expect(wtn("A crab cake")).to.equal("A crab cake");
});

it("A cat and a mouse", () => {
  expect(wtn("A cat and a mouse")).to.equal("A cat and a mouse");
});

// This is a valid case where you'd expect the "a" to mean "one hundred"
it("A hundred cats and dogs", () => {
  expect(wtn("A hundred cats and dogs")).to.equal("100 cats and dogs");
});
```

---

Besides the main change, I made some more cleanup changes to make the code more readable, and organized some files.